### PR TITLE
Upgrading Expo to 31

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
     "description": "This project is a real dummy.",
     "slug": "DummyDemo",
     "privacy": "public",
-    "sdkVersion": "30.0.0",
+    "sdkVersion": "31.0.0",
     "platforms": [
       "ios",
       "android"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^30.0.1",
-    "react": "16.3.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-30.0.0.tar.gz",
-    "react-navigation": "^2.18.0",
+    "expo": "^31.0.4",
+    "react": "16.5.0",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.1.tar.gz",
+    "react-navigation": "^2.18.2",
     "react-redux": "^5.0.7",
     "redux": "^4.0.1",
     "redux-logger": "^3.0.6",


### PR DESCRIPTION
See [Expo's blog post](https://blog.expo.io/expo-sdk-v31-0-0-is-now-available-cad6d0463f49)